### PR TITLE
Fixed "close timed out" during node deployment

### DIFF
--- a/nodes/rcon-ws-server.js
+++ b/nodes/rcon-ws-server.js
@@ -41,15 +41,17 @@ module.exports = function (RED) {
     this.deregister = function (cmdNode, done) {
       delete node.users[cmdNode.id];
       if (node.closing) {
-        return done();
+        done();
       }
       if (Object.keys(node.users).length === 0) {
         if (node.client && node.connected) {
           node.client.close(1000);
           done();
         } else {
-          return done();
+          done();
         }
+      } else {
+        done();
       }
     };
 


### PR DESCRIPTION
If you deploy Node-Red changes, each used rcon node might throw an error message "Error stopping node: Close timed out", due to missing/wrong callback.